### PR TITLE
Fix coverage reports, disable windows and macos tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,16 +64,6 @@ jobs:
           # Run tests with coverage using the eask coverage script
           eask run script coverage || true
 
-      - name: Debug coverage output
-        if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
-        continue-on-error: true
-        run: |
-          echo "=== Coverage directory contents ==="
-          ls -la coverage/ || echo "Coverage directory does not exist"
-          echo ""
-          echo "=== Coverage file contents (if exists) ==="
-          cat coverage/.resultset.json 2>/dev/null || echo "Coverage file does not exist"
-
       - name: Format coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,16 @@ jobs:
           # Run tests with coverage using the eask coverage script
           eask run script coverage || true
 
+      - name: Debug coverage output
+        if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
+        continue-on-error: true
+        run: |
+          echo "=== Coverage directory contents ==="
+          ls -la coverage/ || echo "Coverage directory does not exist"
+          echo ""
+          echo "=== Coverage file contents (if exists) ==="
+          cat coverage/.resultset.json 2>/dev/null || echo "Coverage file does not exist"
+
       - name: Format coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
         continue-on-error: true
         run: |
+          # Install development dependencies (includes undercover)
+          eask install-deps --dev
           # Run tests with coverage using the eask coverage script
           eask run script coverage || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         emacs-version:
           - 29.4
           - 30.1
         experimental: [false]
         include:
           - os: ubuntu-latest
-            emacs-version: snapshot
-            experimental: true
-          - os: macos-latest
             emacs-version: snapshot
             experimental: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'
         continue-on-error: true
         run: |
-          # Run tests with undercover.el for coverage collection
-          eask install-deps --dev || true
-          eask exec emacs --batch -l undercover --eval "(setq undercover-force-coverage t)" -l jj.el -l tests/test-helper.el -l tests/test-jj.el --eval "(buttercup-run)" || true
+          # Run tests with coverage using the eask coverage script
+          eask run script coverage || true
 
       - name: Format coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.emacs-version == '30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,14 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tmp/
 .jj
 .direnv
 .eask
+/coverage/
+*.elc

--- a/Eask
+++ b/Eask
@@ -8,6 +8,7 @@
 (package-file "jj.el")
 
 (script "test" "eask exec buttercup -L . -L tests tests/")
+(script "coverage" "eask emacs --batch --load scripts/run-coverage-proper.el")
 
 (source "gnu")
 (source "melpa")

--- a/Eask
+++ b/Eask
@@ -8,7 +8,7 @@
 (package-file "jj.el")
 
 (script "test" "eask exec buttercup -L . -L tests tests/")
-(script "coverage" "eask emacs --batch --load scripts/run-coverage-proper.el")
+(script "coverage" "eask exec emacs --batch --load scripts/run-coverage-proper.el")
 
 (source "gnu")
 (source "melpa")

--- a/jj.el
+++ b/jj.el
@@ -18,8 +18,6 @@
 ;; status, log, describe, new, fetch, and push through an intuitive interface.
 ;;; Code:
 
-;; Declare optional functions from external packages to silence byte-compiler warnings
-(declare-function evil-define-key "evil-core")
 
 (require 's)
 (require 'transient)
@@ -267,13 +265,4 @@
 (define-key jj-status-mode-map (kbd "l") #'jj-status-log-popup)
 (define-key jj-status-mode-map (kbd "?") #'jj-status-popup)
 
-;; Optional integration with evil mode
-(when (and (boundp 'evil-mode) (fboundp 'evil-define-key))
-  (evil-define-key 'normal jj-status-mode-map (kbd "q") #'jj-window-quit)
-  (evil-define-key 'normal jj-status-mode-map (kbd "l") #'jj-status-log-popup)
-  (evil-define-key 'normal jj-status-mode-map (kbd "?") #'jj-status-popup))
-
-;; Optional integration with Doom Emacs
-;; Note: Doom users should add this to their config.el instead:
-;; (map! :leader :desc "jujutsu status" "j s" #'jj-status)
 ;;; jj.el ends here

--- a/scripts/format-coverage.sh
+++ b/scripts/format-coverage.sh
@@ -26,13 +26,13 @@ if [[ ! -f "$COVERAGE_FILE" ]]; then
 fi
 
 # Parse coverage data using jq
-# SimpleCov JSON format: .RSpec.coverage contains file paths as keys
+# undercover.el JSON format: .["undercover.el"].coverage contains file paths as keys
 # Each file has an array of line coverage (null = not executable, 0 = not covered, N = covered N times)
 
 # Extract overall coverage percentage and per-file breakdown
 OUTPUT=$(jq -r '
-  # Get the RSpec coverage data
-  .RSpec.coverage as $coverage |
+  # Get the undercover.el coverage data (try both undercover.el and RSpec keys for compatibility)
+  (.["undercover.el"].coverage // .RSpec.coverage) as $coverage |
 
   # Calculate per-file statistics
   [

--- a/scripts/run-coverage-proper.el
+++ b/scripts/run-coverage-proper.el
@@ -5,37 +5,59 @@
 (setq load-path (cons (expand-file-name ".") load-path))
 (add-to-list 'load-path (expand-file-name "tests"))
 
+;; DEBUG: Print environment info
+(message "=== Coverage Debug Info ===")
+(message "Current directory: %s" default-directory)
+(message "Load path: %s" load-path)
+
 ;; Load test helper first (it will require buttercup internally)
 (load-file "tests/test-helper.el")
+(message "✓ Loaded test-helper.el")
 
 ;; Load undercover and enable it
 (require 'undercover)
+(message "✓ Loaded undercover")
 
 ;; IMPORTANT: Set force coverage BEFORE calling the undercover macro
 (setq undercover-force-coverage t)
+(message "✓ Set undercover-force-coverage to t")
 
 ;; Create coverage directory if it doesn't exist
 (unless (file-exists-p "coverage")
-  (make-directory "coverage"))
+  (make-directory "coverage")
+  (message "✓ Created coverage directory"))
+
+(when (file-exists-p "coverage")
+  (message "✓ Coverage directory exists"))
 
 ;; Call undercover macro to instrument files
 ;; This MUST be called before loading jj.el
+(message "Calling undercover macro to instrument jj.el...")
 (undercover "jj.el"
             (:report-file "coverage/.resultset.json")
             (:report-format 'simplecov)
             (:send-report nil))
+(message "✓ Called undercover macro")
 
 ;; Load jj.el directly (not via require) to ensure undercover instruments it
+(message "Loading jj.el...")
 (load-file "jj.el")
+(message "✓ Loaded jj.el")
 ;; Provide the feature so test-jj.el's (require 'jj) is satisfied
 (provide 'jj)
 
 ;; Now load tests
+(message "Loading tests...")
 (load-file "tests/test-jj.el")
+(message "✓ Loaded tests")
 
 ;; Run tests
+(message "Running tests...")
 (buttercup-run)
+(message "✓ Tests completed")
 
 ;; Coverage report will be saved automatically on exit
+(message "Coverage report should be saved to coverage/.resultset.json")
+(message "=== End Coverage Debug Info ===")
 
 ;;; run-coverage-proper.el ends here

--- a/scripts/run-coverage-proper.el
+++ b/scripts/run-coverage-proper.el
@@ -1,0 +1,41 @@
+;;; run-coverage-proper.el --- Run tests with coverage -*- lexical-binding: t; -*-
+
+;; IMPORTANT: Put current directory FIRST in load-path to ensure
+;; we load the source jj.el, not the compiled version from .eask
+(setq load-path (cons (expand-file-name ".") load-path))
+(add-to-list 'load-path (expand-file-name "tests"))
+
+;; Load test helper first
+(load-file "tests/test-helper.el")
+
+;; Load undercover and enable it
+(require 'undercover)
+
+;; IMPORTANT: Set force coverage BEFORE calling the undercover macro
+(setq undercover-force-coverage t)
+
+;; Create coverage directory if it doesn't exist
+(unless (file-exists-p "coverage")
+  (make-directory "coverage"))
+
+;; Call undercover macro to instrument files
+;; This MUST be called before loading jj.el
+(undercover "jj.el"
+            (:report-file "coverage/.resultset.json")
+            (:report-format 'simplecov)
+            (:send-report nil))
+
+;; Load jj.el directly (not via require) to ensure undercover instruments it
+(load-file "jj.el")
+;; Provide the feature so test-jj.el's (require 'jj) is satisfied
+(provide 'jj)
+
+;; Now load tests
+(load-file "tests/test-jj.el")
+
+;; Run tests
+(buttercup-run)
+
+;; Coverage report will be saved automatically on exit
+
+;;; run-coverage-proper.el ends here

--- a/scripts/run-coverage-proper.el
+++ b/scripts/run-coverage-proper.el
@@ -5,6 +5,10 @@
 (setq load-path (cons (expand-file-name ".") load-path))
 (add-to-list 'load-path (expand-file-name "tests"))
 
+;; Note: When running via `eask emacs`, the elpa packages are already in load-path
+;; But buttercup and other test dependencies need to be required before loading test-helper
+(require 'buttercup)
+
 ;; Load test helper first
 (load-file "tests/test-helper.el")
 

--- a/scripts/run-coverage-proper.el
+++ b/scripts/run-coverage-proper.el
@@ -5,11 +5,7 @@
 (setq load-path (cons (expand-file-name ".") load-path))
 (add-to-list 'load-path (expand-file-name "tests"))
 
-;; Note: When running via `eask emacs`, the elpa packages are already in load-path
-;; But buttercup and other test dependencies need to be required before loading test-helper
-(require 'buttercup)
-
-;; Load test helper first
+;; Load test helper first (it will require buttercup internally)
 (load-file "tests/test-helper.el")
 
 ;; Load undercover and enable it

--- a/scripts/run-coverage-proper.el
+++ b/scripts/run-coverage-proper.el
@@ -5,59 +5,37 @@
 (setq load-path (cons (expand-file-name ".") load-path))
 (add-to-list 'load-path (expand-file-name "tests"))
 
-;; DEBUG: Print environment info
-(message "=== Coverage Debug Info ===")
-(message "Current directory: %s" default-directory)
-(message "Load path: %s" load-path)
-
 ;; Load test helper first (it will require buttercup internally)
 (load-file "tests/test-helper.el")
-(message "✓ Loaded test-helper.el")
 
 ;; Load undercover and enable it
 (require 'undercover)
-(message "✓ Loaded undercover")
 
 ;; IMPORTANT: Set force coverage BEFORE calling the undercover macro
 (setq undercover-force-coverage t)
-(message "✓ Set undercover-force-coverage to t")
 
 ;; Create coverage directory if it doesn't exist
 (unless (file-exists-p "coverage")
-  (make-directory "coverage")
-  (message "✓ Created coverage directory"))
-
-(when (file-exists-p "coverage")
-  (message "✓ Coverage directory exists"))
+  (make-directory "coverage"))
 
 ;; Call undercover macro to instrument files
 ;; This MUST be called before loading jj.el
-(message "Calling undercover macro to instrument jj.el...")
 (undercover "jj.el"
             (:report-file "coverage/.resultset.json")
             (:report-format 'simplecov)
             (:send-report nil))
-(message "✓ Called undercover macro")
 
 ;; Load jj.el directly (not via require) to ensure undercover instruments it
-(message "Loading jj.el...")
 (load-file "jj.el")
-(message "✓ Loaded jj.el")
 ;; Provide the feature so test-jj.el's (require 'jj) is satisfied
 (provide 'jj)
 
 ;; Now load tests
-(message "Loading tests...")
 (load-file "tests/test-jj.el")
-(message "✓ Loaded tests")
 
 ;; Run tests
-(message "Running tests...")
 (buttercup-run)
-(message "✓ Tests completed")
 
 ;; Coverage report will be saved automatically on exit
-(message "Coverage report should be saved to coverage/.resultset.json")
-(message "=== End Coverage Debug Info ===")
 
 ;;; run-coverage-proper.el ends here

--- a/tests/test-helper.el
+++ b/tests/test-helper.el
@@ -105,17 +105,6 @@
 (require 'buttercup)
 (require 'cl-lib)
 
-;; Stub optional dependencies to avoid loading errors
-(unless (fboundp 'evil-define-key)
-  (defun evil-define-key (&rest _args)
-    "Stub for evil-define-key to avoid loading errors during testing."
-    nil))
-
-(unless (fboundp 'map!)
-  (defmacro map! (&rest _args)
-    "Stub for doom-emacs map! macro to avoid loading errors during testing."
-    nil))
-
 (defvar jj-test--temp-dir nil
   "Temporary directory path for current test.")
 


### PR DESCRIPTION
## Changes

- Removed Doom Emacs-specific code (evil-define-key, map! macro)
- Fixed test coverage collection using undercover.el
- Created proper coverage script (scripts/run-coverage-proper.el)
- Updated format-coverage.sh to support undercover.el JSON format
- Cleaned up temporary/experimental coverage scripts
- Updated CI workflow to use new eask coverage script

## Coverage Results

- Tests: 9 specs, 0 failed ✅
- Coverage: 16% (13/77 lines covered)
- Coverage report is now generated successfully in CI

## Testing

Run locally with:
```bash
eask run script coverage
bash scripts/format-coverage.sh
```