### PR TITLE
Fix keyword mismatch warnings between Eask and package file

### DIFF
--- a/Eask
+++ b/Eask
@@ -3,7 +3,7 @@
          "Integration with jujutsu version control system")
 
 (website-url "https://github.com/fstaffa/jj.el")
-(keywords "jj" "jujutsu" "vcs")
+(keywords "vc" "jj" "jujutsu" "vcs")
 
 (package-file "jj.el")
 

--- a/jj.el
+++ b/jj.el
@@ -8,7 +8,7 @@
 ;; Modified: February 28, 2025
 ;; Version: 0.0.1
 ;; Package-Requires: ((emacs "28.1") (s "1.13.0") (transient "0.8.0"))
-;; Keywords: vc
+;; Keywords: vc jj jujutsu vcs
 ;; URL: https://github.com/fstaffa/jj.el
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
## Summary
- Synchronized keywords between Eask file and jj.el package file
- Added "vc" keyword to Eask file
- Added "jj", "jujutsu", "vcs" keywords to jj.el file
- Eliminates all keyword mismatch warnings during test runs

## Changes
- **Eask**: Added "vc" to keywords list
- **jj.el**: Expanded Keywords header from "vc" to "vc jj jujutsu vcs"

## Test Results
All 60 tests pass with no warnings.

related to: https://github.com/fstaffa/jj.el/issues/ISSUE_NUMBER