### PR TITLE
Remove task group organization from test files

### DIFF
--- a/tests/test-jj-auto-refresh.el
+++ b/tests/test-jj-auto-refresh.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; Tests for Task Group 7: Auto-refresh Integration
+;; Tests for Auto-refresh Integration
 ;; ================================================
 ;;
 ;; This file tests the auto-refresh functionality that triggers status

--- a/tests/test-jj-navigation.el
+++ b/tests/test-jj-navigation.el
@@ -1,7 +1,7 @@
 ;;; test-jj-navigation.el --- Tests for jj-status navigation  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
-;; High-level integration tests for Task Group 4: Navigation System
+;; High-level integration tests for Navigation System
 ;; Tests navigation functions on real jj-status buffers
 ;;
 ;; NOTE: Some tests are skipped on Emacs 29.x due to text property
@@ -15,202 +15,200 @@
 
 ;; No helper function needed - we'll use assume directly
 
-(describe "Task Group 4: Navigation System"
+(describe "jj-status-next-item"
+  (it "should navigate to first file in Working Copy Changes section"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n"
+       :status-output "Working copy changes:\nM file1.txt\nA file2.txt\n"
+       :bookmark-output "main: yqosqzyt abc123 Add feature\n")
+      ;; Start at beginning of buffer
+      (goto-char (point-min))
+      ;; Navigate to first item
+      (jj-status-next-item)
+      ;; Should be on a file item
+      (let ((item (get-text-property (point) 'jj-item)))
+        (expect item :not :to-be nil)
+        (expect (plist-get item :status) :to-equal "M")
+        (expect (plist-get item :path) :to-equal "file1.txt"))))
 
-  (describe "jj-status-next-item"
-    (it "should navigate to first file in Working Copy Changes section"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n"
-         :status-output "Working copy changes:\nM file1.txt\nA file2.txt\n"
-         :bookmark-output "main: yqosqzyt abc123 Add feature\n")
-        ;; Start at beginning of buffer
-        (goto-char (point-min))
-        ;; Navigate to first item
-        (jj-status-next-item)
-        ;; Should be on a file item
-        (let ((item (get-text-property (point) 'jj-item)))
-          (expect item :not :to-be nil)
-          (expect (plist-get item :status) :to-equal "M")
-          (expect (plist-get item :path) :to-equal "file1.txt"))))
+  (it "should navigate between multiple files"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\nA file2.txt\nR file3.txt\n"
+       :bookmark-output "")
+      (goto-char (point-min))
+      ;; Navigate to first file
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
+      ;; Navigate to second file
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file2.txt")
+      ;; Navigate to third file
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file3.txt")))
 
-    (it "should navigate between multiple files"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\nA file2.txt\nR file3.txt\n"
-         :bookmark-output "")
-        (goto-char (point-min))
-        ;; Navigate to first file
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
-        ;; Navigate to second file
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file2.txt")
-        ;; Navigate to third file
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file3.txt")))
+  (it "should navigate to revisions in Revisions section"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n◉  mzvwutvl | Fix bug | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Start in files section
+      (goto-char (point-min))
+      (jj-status-next-item)
+      ;; Should be on file
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
+      ;; Navigate to first revision
+      (jj-status-next-item)
+      (let ((item (get-text-property (point) 'jj-item)))
+        (expect (plist-get item :change-id) :to-equal "qpvuntsm"))
+      ;; Navigate to second revision
+      (jj-status-next-item)
+      (let ((item (get-text-property (point) 'jj-item)))
+        (expect (plist-get item :change-id) :to-equal "yqosqzyt"))))
 
-    (it "should navigate to revisions in Revisions section"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n◉  mzvwutvl | Fix bug | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Start in files section
-        (goto-char (point-min))
-        (jj-status-next-item)
-        ;; Should be on file
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
-        ;; Navigate to first revision
-        (jj-status-next-item)
-        (let ((item (get-text-property (point) 'jj-item)))
-          (expect (plist-get item :change-id) :to-equal "qpvuntsm"))
-        ;; Navigate to second revision
-        (jj-status-next-item)
-        (let ((item (get-text-property (point) 'jj-item)))
-          (expect (plist-get item :change-id) :to-equal "yqosqzyt"))))
+  (it "should wrap around to beginning when at end of buffer"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Navigate to the file
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
+      ;; Navigate to revision
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm")
+      ;; At end, should wrap to first item (file1.txt)
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
 
-    (it "should wrap around to beginning when at end of buffer"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Navigate to the file
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
-        ;; Navigate to revision
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm")
-        ;; At end, should wrap to first item (file1.txt)
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
+  (it "should skip non-item lines (headers, blank lines)"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Start at point-min (on header)
+      (goto-char (point-min))
+      ;; First next-item should skip header and go to file
+      (jj-status-next-item)
+      (let ((item (get-text-property (point) 'jj-item)))
+        (expect item :not :to-be nil)
+        (expect (plist-get item :path) :to-equal "file1.txt")))))
 
-    (it "should skip non-item lines (headers, blank lines)"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Start at point-min (on header)
-        (goto-char (point-min))
-        ;; First next-item should skip header and go to file
-        (jj-status-next-item)
-        (let ((item (get-text-property (point) 'jj-item)))
-          (expect item :not :to-be nil)
-          (expect (plist-get item :path) :to-equal "file1.txt")))))
+(describe "jj-status-prev-item"
+  (it "should navigate backwards from revision to file"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Navigate to revision first
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm")
+      ;; Now go back to file
+      (jj-status-prev-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
 
-  (describe "jj-status-prev-item"
-    (it "should navigate backwards from revision to file"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Navigate to revision first
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm")
-        ;; Now go back to file
-        (jj-status-prev-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
+  (it "should navigate backwards through multiple files"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\nA file2.txt\nR file3.txt\n"
+       :bookmark-output "")
+      ;; Navigate to last file
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (jj-status-next-item)
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file3.txt")
+      ;; Navigate backwards
+      (jj-status-prev-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file2.txt")
+      (jj-status-prev-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
 
-    (it "should navigate backwards through multiple files"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\nA file2.txt\nR file3.txt\n"
-         :bookmark-output "")
-        ;; Navigate to last file
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (jj-status-next-item)
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file3.txt")
-        ;; Navigate backwards
-        (jj-status-prev-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file2.txt")
-        (jj-status-prev-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")))
+  (it "should wrap around to end when at beginning"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Navigate to first file
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
+      ;; Go backwards - should wrap to last item (revision)
+      (jj-status-prev-item)
+      (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm"))))
 
-    (it "should wrap around to end when at beginning"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Navigate to first file
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :path) :to-equal "file1.txt")
-        ;; Go backwards - should wrap to last item (revision)
-        (jj-status-prev-item)
-        (expect (plist-get (get-text-property (point) 'jj-item) :change-id) :to-equal "qpvuntsm"))))
+(describe "jj-status--item-at-point"
+  (it "should return file item when on file line"
+    (assume (not (version< emacs-version "30.0")) "Text properties unreliable in Emacs 29.x special-mode buffers")
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (let ((result (jj-status--item-at-point)))
+        (expect (plist-get result :type) :to-be 'file)
+        (expect (plist-get (plist-get result :data) :path) :to-equal "file1.txt")
+        (expect (plist-get (plist-get result :data) :status) :to-equal "M"))))
 
-  (describe "jj-status--item-at-point"
-    (it "should return file item when on file line"
-      (assume (not (version< emacs-version "30.0")) "Text properties unreliable in Emacs 29.x special-mode buffers")
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (let ((result (jj-status--item-at-point)))
-          (expect (plist-get result :type) :to-be 'file)
-          (expect (plist-get (plist-get result :data) :path) :to-equal "file1.txt")
-          (expect (plist-get (plist-get result :data) :status) :to-equal "M"))))
+  (it "should return revision item when on revision line"
+    (assume (not (version< emacs-version "30.0")) "Text properties unreliable in Emacs 29.x special-mode buffers")
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n"
+       :status-output "Working copy changes:\n"
+       :bookmark-output "")
+      (goto-char (point-min))
+      (jj-status-next-item)
+      (let ((result (jj-status--item-at-point)))
+        (expect (plist-get result :type) :to-be 'revision)
+        (expect (plist-get (plist-get result :data) :change-id) :to-equal "qpvuntsm")
+        (expect (plist-get (plist-get result :data) :description) :to-equal "Working copy"))))
 
-    (it "should return revision item when on revision line"
-      (assume (not (version< emacs-version "30.0")) "Text properties unreliable in Emacs 29.x special-mode buffers")
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n◉  yqosqzyt | Add feature | main\n"
-         :status-output "Working copy changes:\n"
-         :bookmark-output "")
-        (goto-char (point-min))
-        (jj-status-next-item)
-        (let ((result (jj-status--item-at-point)))
-          (expect (plist-get result :type) :to-be 'revision)
-          (expect (plist-get (plist-get result :data) :change-id) :to-equal "qpvuntsm")
-          (expect (plist-get (plist-get result :data) :description) :to-equal "Working copy"))))
+  (it "should return nil when on non-item line (header)"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\n"
+       :bookmark-output "")
+      ;; Position on header
+      (goto-char (point-min))
+      (let ((result (jj-status--item-at-point)))
+        (expect (plist-get result :type) :to-be nil)
+        (expect (plist-get result :data) :to-be nil)))))
 
-    (it "should return nil when on non-item line (header)"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\n"
-         :bookmark-output "")
-        ;; Position on header
-        (goto-char (point-min))
-        (let ((result (jj-status--item-at-point)))
-          (expect (plist-get result :type) :to-be nil)
-          (expect (plist-get result :data) :to-be nil)))))
+(describe "jj-status-show-diff"
+  (it "should show placeholder message for files"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\nM file1.txt\n"
+       :bookmark-output "")
+      ;; Navigate to file
+      (goto-char (point-min))
+      (jj-status-next-item)
+      ;; Call show-diff - should not error, just show message
+      (expect (jj-status-show-diff) :not :to-throw)))
 
-  (describe "jj-status-show-diff"
-    (it "should show placeholder message for files"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\nM file1.txt\n"
-         :bookmark-output "")
-        ;; Navigate to file
-        (goto-char (point-min))
-        (jj-status-next-item)
-        ;; Call show-diff - should not error, just show message
-        (expect (jj-status-show-diff) :not :to-throw)))
+  (it "should show placeholder message for revisions"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\n"
+       :bookmark-output "")
+      ;; Navigate to revision
+      (goto-char (point-min))
+      (jj-status-next-item)
+      ;; Call show-diff - should not error
+      (expect (jj-status-show-diff) :not :to-throw)))
 
-    (it "should show placeholder message for revisions"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\n"
-         :bookmark-output "")
-        ;; Navigate to revision
-        (goto-char (point-min))
-        (jj-status-next-item)
-        ;; Call show-diff - should not error
-        (expect (jj-status-show-diff) :not :to-throw)))
-
-    (it "should handle being called on non-item lines"
-      (jj-test-with-status-buffer
-        (:log-output "@  qpvuntsm | Working copy | \n"
-         :status-output "Working copy changes:\n"
-         :bookmark-output "")
-        ;; Position on header (non-item)
-        (goto-char (point-min))
-        ;; Should not error
-        (expect (jj-status-show-diff) :not :to-throw)))))
+  (it "should handle being called on non-item lines"
+    (jj-test-with-status-buffer
+      (:log-output "@  qpvuntsm | Working copy | \n"
+       :status-output "Working copy changes:\n"
+       :bookmark-output "")
+      ;; Position on header (non-item)
+      (goto-char (point-min))
+      ;; Should not error
+      (expect (jj-status-show-diff) :not :to-throw))))
 
 ;;; test-jj-navigation.el ends here

--- a/tests/test-jj-rendering.el
+++ b/tests/test-jj-rendering.el
@@ -5,7 +5,7 @@
 ;; Unit Tests for jj.el Buffer Rendering Functions
 ;; ===============================================
 ;;
-;; This file contains focused tests for Task Group 3: Buffer Rendering System.
+;; This file contains focused tests for Buffer Rendering System.
 ;; Tests verify section rendering, face application, and formatting logic.
 ;;
 ;; Test Coverage:

--- a/tests/test-jj-staging.el
+++ b/tests/test-jj-staging.el
@@ -6,13 +6,13 @@
 ;; =========================================
 ;;
 ;; This file contains tests for the file staging system.
-;; Tests are organized by task group following the spec in
+;; Tests are organized by  following the spec in
 ;; agent-os/specs/2025-10-17-magit-like-status-buffer/
 ;;
 ;; Test Coverage Summary
 ;; ---------------------
 ;;
-;; Task Group 5: File Staging System (2-8 tests)
+;; File Staging System (2-8 tests)
 ;;   - jj-status--find-last-described-revision
 ;;   - jj-status--validate-staging-target
 ;;   - jj-status-stage-file
@@ -37,128 +37,126 @@
 (require 'test-helper)
 (require 'jj)
 
-;; Task Group 5: File Staging System Tests
+;; File Staging System Tests
 ;; ----------------------------------------
 ;; Tests for the staging functionality including finding last described
 ;; revision, validation, and staging command execution.
 
-(describe "Task Group 5: File Staging System"
+(describe "jj-status--find-last-described-revision"
+  (it "should find most recent revision with description"
+    (let ((revisions '((:graph-line "@  " :change-id "abc123" :description "")
+                       (:graph-line "○  " :change-id "def456" :description "Add feature")
+                       (:graph-line "○  " :change-id "ghi789" :description "Fix bug"))))
+      (let ((result (jj-status--find-last-described-revision revisions)))
+        (expect (plist-get result :change-id) :to-equal "def456")
+        (expect (plist-get result :description) :to-equal "Add feature"))))
 
-  (describe "jj-status--find-last-described-revision"
-    (it "should find most recent revision with description"
-      (let ((revisions '((:graph-line "@  " :change-id "abc123" :description "")
-                         (:graph-line "○  " :change-id "def456" :description "Add feature")
-                         (:graph-line "○  " :change-id "ghi789" :description "Fix bug"))))
-        (let ((result (jj-status--find-last-described-revision revisions)))
-          (expect (plist-get result :change-id) :to-equal "def456")
-          (expect (plist-get result :description) :to-equal "Add feature"))))
+  (it "should return nil when no described revision exists"
+    (let ((revisions '((:graph-line "@  " :change-id "abc123" :description "")
+                       (:graph-line "○  " :change-id "def456" :description ""))))
+      (expect (jj-status--find-last-described-revision revisions) :to-be nil)))
 
-    (it "should return nil when no described revision exists"
-      (let ((revisions '((:graph-line "@  " :change-id "abc123" :description "")
-                         (:graph-line "○  " :change-id "def456" :description ""))))
-        (expect (jj-status--find-last-described-revision revisions) :to-be nil)))
+  (it "should iterate from top of list (most recent)"
+    (let ((revisions '((:graph-line "○  " :change-id "new123" :description "Latest change")
+                       (:graph-line "○  " :change-id "old456" :description "Old change"))))
+      (let ((result (jj-status--find-last-described-revision revisions)))
+        (expect (plist-get result :change-id) :to-equal "new123"))))
 
-    (it "should iterate from top of list (most recent)"
-      (let ((revisions '((:graph-line "○  " :change-id "new123" :description "Latest change")
-                         (:graph-line "○  " :change-id "old456" :description "Old change"))))
-        (let ((result (jj-status--find-last-described-revision revisions)))
-          (expect (plist-get result :change-id) :to-equal "new123"))))
+  (it "should return nil for empty revision list"
+    (expect (jj-status--find-last-described-revision '()) :to-be nil)))
 
-    (it "should return nil for empty revision list"
-      (expect (jj-status--find-last-described-revision '()) :to-be nil)))
+(describe "jj-status--validate-staging-target"
+  (it "should return t when revision is mutable"
+    (jj-test-with-mocked-command
+      '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
+         :exit-code 0
+         :stdout "other123\nother456\n"
+         :stderr ""))
+      (jj-test-with-project-folder "/tmp/test"
+        (expect (jj-status--validate-staging-target "abc123") :to-be t))))
 
-  (describe "jj-status--validate-staging-target"
-    (it "should return t when revision is mutable"
+  (it "should return nil when revision is immutable"
+    (jj-test-with-mocked-command
+      '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
+         :exit-code 0
+         :stdout "abc123\ndef456\n"
+         :stderr ""))
+      (jj-test-with-project-folder "/tmp/test"
+        (expect (jj-status--validate-staging-target "abc123") :to-be nil)))))
+
+(describe "jj-status-stage-file"
+  (it "should error when not on a file"
+    (with-temp-buffer
+      (jj-status-mode)
+      (expect (jj-status-stage-file) :to-throw 'user-error)))
+
+  (it "should error when no described revision found"
+    (with-temp-buffer
+      (jj-status-mode)
+      ;; Set buffer-local parsed-data with no described revision
+      (setq-local jj-status--parsed-data
+                  (list :revisions '((:graph-line "@  " :change-id "abc123" :description ""))
+                        :files '()
+                        :bookmarks '()))
+      ;; Insert a file item
+      (let ((inhibit-read-only t))
+        (insert "  M  test.txt\n")
+        (jj-status--mark-item-bounds (point-min) (point)
+                                     '(:path "test.txt" :status "M")))
+      (goto-char (point-min))
+      (expect (jj-status-stage-file) :to-throw 'user-error)))
+
+  (it "should error when target revision is immutable"
+    (jj-test-with-mocked-command
+      '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
+         :exit-code 0
+         :stdout "def456\n"
+         :stderr ""))
+      (jj-test-with-project-folder "/tmp/test"
+        (with-temp-buffer
+          (jj-status-mode)
+          ;; Set buffer-local parsed-data
+          (setq-local jj-status--parsed-data
+                      (list :revisions '((:graph-line "○  " :change-id "def456" :description "Add feature"))
+                            :files '()
+                            :bookmarks '()))
+          ;; Insert a file item
+          (let ((inhibit-read-only t))
+            (insert "  M  test.txt\n")
+            (jj-status--mark-item-bounds (point-min) (point)
+                                         '(:path "test.txt" :status "M")))
+          (goto-char (point-min))
+          (expect (jj-status-stage-file) :to-throw 'user-error)))))
+
+  (it "should execute squash command and refresh on success"
+    (let ((squash-executed nil)
+          (refresh-called nil))
       (jj-test-with-mocked-command
         '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
            :exit-code 0
-           :stdout "other123\nother456\n"
-           :stderr ""))
-        (jj-test-with-project-folder "/tmp/test"
-          (expect (jj-status--validate-staging-target "abc123") :to-be t))))
-
-    (it "should return nil when revision is immutable"
-      (jj-test-with-mocked-command
-        '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
+           :stdout "other123\n"
+           :stderr "")
+          ("jj" ("--no-pager" "--color" "never" "squash" "--from" "@" "--into" "def456" "test.txt")
            :exit-code 0
-           :stdout "abc123\ndef456\n"
+           :stdout "Squashed changes\n"
            :stderr ""))
         (jj-test-with-project-folder "/tmp/test"
-          (expect (jj-status--validate-staging-target "abc123") :to-be nil)))))
-
-  (describe "jj-status-stage-file"
-    (it "should error when not on a file"
-      (with-temp-buffer
-        (jj-status-mode)
-        (expect (jj-status-stage-file) :to-throw 'user-error)))
-
-    (it "should error when no described revision found"
-      (with-temp-buffer
-        (jj-status-mode)
-        ;; Set buffer-local parsed-data with no described revision
-        (setq-local jj-status--parsed-data
-                    (list :revisions '((:graph-line "@  " :change-id "abc123" :description ""))
-                          :files '()
-                          :bookmarks '()))
-        ;; Insert a file item
-        (let ((inhibit-read-only t))
-          (insert "  M  test.txt\n")
-          (jj-status--mark-item-bounds (point-min) (point)
-                                       '(:path "test.txt" :status "M")))
-        (goto-char (point-min))
-        (expect (jj-status-stage-file) :to-throw 'user-error)))
-
-    (it "should error when target revision is immutable"
-      (jj-test-with-mocked-command
-        '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
-           :exit-code 0
-           :stdout "def456\n"
-           :stderr ""))
-        (jj-test-with-project-folder "/tmp/test"
-          (with-temp-buffer
-            (jj-status-mode)
-            ;; Set buffer-local parsed-data
-            (setq-local jj-status--parsed-data
-                        (list :revisions '((:graph-line "○  " :change-id "def456" :description "Add feature"))
-                              :files '()
-                              :bookmarks '()))
-            ;; Insert a file item
-            (let ((inhibit-read-only t))
-              (insert "  M  test.txt\n")
-              (jj-status--mark-item-bounds (point-min) (point)
-                                           '(:path "test.txt" :status "M")))
-            (goto-char (point-min))
-            (expect (jj-status-stage-file) :to-throw 'user-error)))))
-
-    (it "should execute squash command and refresh on success"
-      (let ((squash-executed nil)
-            (refresh-called nil))
-        (jj-test-with-mocked-command
-          '(("jj" ("--no-pager" "--color" "never" "log" "-r" "immutable_heads()" "-T" "change_id" "--no-graph")
-             :exit-code 0
-             :stdout "other123\n"
-             :stderr "")
-            ("jj" ("--no-pager" "--color" "never" "squash" "--from" "@" "--into" "def456" "test.txt")
-             :exit-code 0
-             :stdout "Squashed changes\n"
-             :stderr ""))
-          (jj-test-with-project-folder "/tmp/test"
-            (cl-letf (((symbol-function 'jj-status-refresh)
-                       (lambda () (setq refresh-called t))))
-              (with-temp-buffer
-                (jj-status-mode)
-                ;; Set buffer-local parsed-data
-                (setq-local jj-status--parsed-data
-                            (list :revisions '((:graph-line "○  " :change-id "def456" :description "Add feature"))
-                                  :files '()
-                                  :bookmarks '()))
-                ;; Insert a file item
-                (let ((inhibit-read-only t))
-                  (insert "  M  test.txt\n")
-                  (jj-status--mark-item-bounds (point-min) (point)
-                                               '(:path "test.txt" :status "M")))
-                (goto-char (point-min))
-                (jj-status-stage-file)
-                (expect refresh-called :to-be t)))))))))
+          (cl-letf (((symbol-function 'jj-status-refresh)
+                     (lambda () (setq refresh-called t))))
+            (with-temp-buffer
+              (jj-status-mode)
+              ;; Set buffer-local parsed-data
+              (setq-local jj-status--parsed-data
+                          (list :revisions '((:graph-line "○  " :change-id "def456" :description "Add feature"))
+                                :files '()
+                                :bookmarks '()))
+              ;; Insert a file item
+              (let ((inhibit-read-only t))
+                (insert "  M  test.txt\n")
+                (jj-status--mark-item-bounds (point-min) (point)
+                                             '(:path "test.txt" :status "M")))
+              (goto-char (point-min))
+              (jj-status-stage-file)
+              (expect refresh-called :to-be t))))))))
 
 ;;; test-jj-staging.el ends here

--- a/tests/test-jj-status-integration.el
+++ b/tests/test-jj-status-integration.el
@@ -6,7 +6,7 @@
 ;; ==========================================================
 ;;
 ;; This file contains strategic integration tests to fill critical coverage gaps
-;; identified in Task Group 8: Test Review & Gap Analysis.
+;; identified in Test Review & Gap Analysis.
 ;;
 ;; Test Coverage:
 ;;   - End-to-end workflow integration tests

--- a/tests/test-jj-status-parsing.el
+++ b/tests/test-jj-status-parsing.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; Tests for Task Group 2: Output Parsing & Data Structures
+;; Tests for Output Parsing & Data Structures
 ;;
 ;; This file contains focused tests for the parsing layer of the magit-like
 ;; status buffer feature. Tests verify that jj command outputs are correctly

--- a/tests/test-jj-status-refresh.el
+++ b/tests/test-jj-status-refresh.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; Tests for Task Group 6: Buffer Refresh System
+;; Tests for Buffer Refresh System
 ;; =============================================
 ;;
 ;; This file tests the buffer refresh functionality for the magit-like

--- a/tests/test-jj-status.el
+++ b/tests/test-jj-status.el
@@ -6,13 +6,13 @@
 ;; ===================================================
 ;;
 ;; This file contains tests for the magit-like status buffer feature.
-;; Tests are organized by task group following the spec in
+;; Tests are organized by  following the spec in
 ;; agent-os/specs/2025-10-17-magit-like-status-buffer/
 ;;
 ;; Test Coverage Summary
 ;; ---------------------
 ;;
-;; Task Group 1: Command Execution Infrastructure (2-8 tests)
+;; Command Execution Infrastructure (2-8 tests)
 ;;   - jj-status--fetch-revision-list
 ;;   - jj-status--fetch-working-copy-status
 ;;   - jj-status--fetch-bookmark-list
@@ -37,98 +37,96 @@
 (require 'test-helper)
 (require 'jj)
 
-;; Task Group 1: Command Execution Infrastructure Tests
+;; Command Execution Infrastructure Tests
 ;; -----------------------------------------------------
 ;; Tests for the three fetch functions that execute jj commands
 ;; and return raw output strings.
 
-(describe "Task Group 1: Command Execution Infrastructure"
+(describe "jj-status--fetch-revision-list"
+  (it "should execute jj log command with graph and custom template"
+    (let ((expected-cmd '("log" "--revisions" "immutable_heads()..@" "-T" "change_id ++ ' | ' ++ description.first_line() ++ ' | ' ++ bookmarks"))
+          (sample-output "@  qpvuntsmqxuquz57\nWorking copy\n\n")
+          (captured-command nil))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (cmd)
+                   (setq captured-command cmd)
+                   (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (let ((result (jj-status--fetch-revision-list)))
+            (expect captured-command :to-equal expected-cmd)
+            (expect result :to-equal sample-output))))))
 
-  (describe "jj-status--fetch-revision-list"
-    (it "should execute jj log command with graph and custom template"
-      (let ((expected-cmd '("log" "--revisions" "immutable_heads()..@" "-T" "change_id ++ ' | ' ++ description.first_line() ++ ' | ' ++ bookmarks"))
-            (sample-output "@  qpvuntsmqxuquz57\nWorking copy\n\n")
-            (captured-command nil))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (cmd)
-                     (setq captured-command cmd)
-                     (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (let ((result (jj-status--fetch-revision-list)))
-              (expect captured-command :to-equal expected-cmd)
-              (expect result :to-equal sample-output))))))
+  (it "should return raw command output string"
+    (let ((sample-output "◉  yqosqzytrlsw\nAdd feature\nmain\n"))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (_cmd) (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (expect (jj-status--fetch-revision-list) :to-equal sample-output)))))
 
-    (it "should return raw command output string"
-      (let ((sample-output "◉  yqosqzytrlsw\nAdd feature\nmain\n"))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (_cmd) (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (expect (jj-status--fetch-revision-list) :to-equal sample-output)))))
+  (it "should use jj--with-command for error handling"
+    (let ((validation-called nil))
+      (cl-letf (((symbol-function 'jj--validate-repository)
+                 (lambda ()
+                   (setq validation-called t)
+                   "/tmp/test/"))
+                ((symbol-function 'jj--run-command)
+                 (lambda (_cmd) (list t "output" "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (jj-status--fetch-revision-list)
+          (expect validation-called :to-be t))))))
 
-    (it "should use jj--with-command for error handling"
-      (let ((validation-called nil))
-        (cl-letf (((symbol-function 'jj--validate-repository)
-                   (lambda ()
-                     (setq validation-called t)
-                     "/tmp/test/"))
-                  ((symbol-function 'jj--run-command)
-                   (lambda (_cmd) (list t "output" "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (jj-status--fetch-revision-list)
-            (expect validation-called :to-be t))))))
+(describe "jj-status--fetch-working-copy-status"
+  (it "should execute jj status command"
+    (let ((expected-cmd '("status"))
+          (sample-output "Working copy changes:\nA src/file.el\n")
+          (captured-command nil))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (cmd)
+                   (setq captured-command cmd)
+                   (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (let ((result (jj-status--fetch-working-copy-status)))
+            (expect captured-command :to-equal expected-cmd)
+            (expect result :to-equal sample-output))))))
 
-  (describe "jj-status--fetch-working-copy-status"
-    (it "should execute jj status command"
-      (let ((expected-cmd '("status"))
-            (sample-output "Working copy changes:\nA src/file.el\n")
-            (captured-command nil))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (cmd)
-                     (setq captured-command cmd)
-                     (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (let ((result (jj-status--fetch-working-copy-status)))
-              (expect captured-command :to-equal expected-cmd)
-              (expect result :to-equal sample-output))))))
+  (it "should return raw command output string"
+    (let ((sample-output "Working copy changes:\nM src/existing.el\n"))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (_cmd) (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (expect (jj-status--fetch-working-copy-status) :to-equal sample-output))))))
 
-    (it "should return raw command output string"
-      (let ((sample-output "Working copy changes:\nM src/existing.el\n"))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (_cmd) (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (expect (jj-status--fetch-working-copy-status) :to-equal sample-output))))))
+(describe "jj-status--fetch-bookmark-list"
+  (it "should execute jj bookmark list command with custom template"
+    (let ((expected-cmd '("bookmark" "list"))
+          (sample-output "main\tqpvuntsmqxuquz57\ndev\tyqosqzytrlsw\n")
+          (captured-command nil))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (cmd)
+                   (setq captured-command cmd)
+                   (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (let ((result (jj-status--fetch-bookmark-list)))
+            (expect captured-command :to-equal expected-cmd)
+            (expect result :to-equal sample-output))))))
 
-  (describe "jj-status--fetch-bookmark-list"
-    (it "should execute jj bookmark list command with custom template"
-      (let ((expected-cmd '("bookmark" "list"))
-            (sample-output "main\tqpvuntsmqxuquz57\ndev\tyqosqzytrlsw\n")
-            (captured-command nil))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (cmd)
-                     (setq captured-command cmd)
-                     (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (let ((result (jj-status--fetch-bookmark-list)))
-              (expect captured-command :to-equal expected-cmd)
-              (expect result :to-equal sample-output))))))
+  (it "should return raw command output string"
+    (let ((sample-output "feature\tmzvwutvlkqwt\n"))
+      (cl-letf (((symbol-function 'jj--run-command)
+                 (lambda (_cmd) (list t sample-output "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (expect (jj-status--fetch-bookmark-list) :to-equal sample-output)))))
 
-    (it "should return raw command output string"
-      (let ((sample-output "feature\tmzvwutvlkqwt\n"))
-        (cl-letf (((symbol-function 'jj--run-command)
-                   (lambda (_cmd) (list t sample-output "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (expect (jj-status--fetch-bookmark-list) :to-equal sample-output)))))
-
-    (it "should use jj--with-command error handling pattern"
-      (let ((validation-called nil))
-        (cl-letf (((symbol-function 'jj--validate-repository)
-                   (lambda ()
-                     (setq validation-called t)
-                     "/tmp/test/"))
-                  ((symbol-function 'jj--run-command)
-                   (lambda (_cmd) (list t "output" "" 0))))
-          (jj-test-with-project-folder "/tmp/test"
-            (jj-status--fetch-bookmark-list)
-            (expect validation-called :to-be t)))))))
+  (it "should use jj--with-command error handling pattern"
+    (let ((validation-called nil))
+      (cl-letf (((symbol-function 'jj--validate-repository)
+                 (lambda ()
+                   (setq validation-called t)
+                   "/tmp/test/"))
+                ((symbol-function 'jj--run-command)
+                 (lambda (_cmd) (list t "output" "" 0))))
+        (jj-test-with-project-folder "/tmp/test"
+          (jj-status--fetch-bookmark-list)
+          (expect validation-called :to-be t))))))
 
 ;;; test-jj-status.el ends here


### PR DESCRIPTION
Removed task group references and top-level describe blocks from test files to simplify test organization.

Changes:
- Removed all mentions of 'Task Group X:' from test file comments and describe blocks
- Removed top-level describe blocks in test-jj-navigation.el, test-jj-status.el, and test-jj-staging.el
- Unindented nested describe blocks that were inside the removed top-level blocks
- All 132 tests continue to pass

This is a cleanup task to simplify the test file structure.